### PR TITLE
Claim improv3

### DIFF
--- a/src/components/claims/dusp/ClaimListDusp.tsx
+++ b/src/components/claims/dusp/ClaimListDusp.tsx
@@ -238,8 +238,11 @@ export function ClaimListDusp() {
                 <TableCell>
                   <Badge variant={claim.payment_status ? "success" : "warning"}>{claim.payment_status ? "Paid" : "Unpaid"}</Badge>
                 </TableCell>
-                <TableCell>{new Date(claim.updated_at).toLocaleString("en-US", { timeZone: "Asia/Kuala_Lumpur" })}</TableCell>
                 <TableCell>
+                  {claim?.updated_at
+                    ? new Date(new Date(claim.updated_at).getTime() + 8 * 60 * 60 * 1000).toLocaleString("en-GB")
+                    : "N/A"}
+                </TableCell>                <TableCell>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button size="sm" variant="outline" onClick={() => handleView(claim.id)}>

--- a/src/components/claims/dusp/DuspSubmitDialog.tsx
+++ b/src/components/claims/dusp/DuspSubmitDialog.tsx
@@ -28,7 +28,7 @@ const DuspSubmitDialog: React.FC<DuspSubmitDialogProps> = ({ isOpen, onClose, cl
       // Invalidate the query to refresh the ClaimList
       queryClient.invalidateQueries({ queryKey: ["claimStats"] });
       queryClient.invalidateQueries({ queryKey: ["fetchClaimDUSP"] });
-      queryClient.invalidateQueries({ queryKey: ["fetchClaimById", claim.id] });
+      queryClient.invalidateQueries({ queryKey: ["fetchClaimById"] });
 
 
       onClose();

--- a/src/components/claims/dusp/DuspUpdatePaymentDialog.tsx
+++ b/src/components/claims/dusp/DuspUpdatePaymentDialog.tsx
@@ -33,7 +33,7 @@ const DuspUpdatePaymentDialog: React.FC<DuspUpdatePaymentDialogProps> = ({ isOpe
       // Invalidate the query to refresh the ClaimList
       queryClient.invalidateQueries({ queryKey: ["claimStats"] });
       queryClient.invalidateQueries({ queryKey: ["fetchClaimDUSP"] });
-      queryClient.invalidateQueries({ queryKey: ["fetchClaimById", claim.id] });
+      queryClient.invalidateQueries({ queryKey: ["fetchClaimById"] });
 
       onClose();
     } catch (error) {

--- a/src/components/claims/dusp/hooks/fetch-claim-dusp.ts
+++ b/src/components/claims/dusp/hooks/fetch-claim-dusp.ts
@@ -8,7 +8,7 @@ export const useFetchClaimDUSP = () => {
   const organizationId = parsedMetadata?.organization_id;
 
   return useQuery({
-    queryKey: ["fetchClaimDUSP", organizationId],
+    queryKey: ["fetchClaimDUSP"],
     queryFn: async () => {
       if (!organizationId) return [];
 

--- a/src/components/claims/tp/ClaimListTp.tsx
+++ b/src/components/claims/tp/ClaimListTp.tsx
@@ -227,8 +227,11 @@ export function ClaimListTp() {
                   <Badge className="min-w-[6rem] text-center" variant={getStatusBadgeVariant(claim.claim_status.name)}>{claim.claim_status.name}</Badge>
                   <Button size="sm" variant="outline" className="rounded-full p-0 w-6 h-6 flex items-center justify-center" onClick={() => handleOpenDescriptionDialog(claim.claim_status.name)}>i</Button>
                 </TableCell>
-                <TableCell>{new Date(claim.updated_at).toLocaleString("en-US", { timeZone: "Asia/Kuala_Lumpur" })}</TableCell>
                 <TableCell>
+                  {claim?.updated_at
+                    ? new Date(new Date(claim.updated_at).getTime() + 8 * 60 * 60 * 1000).toLocaleString("en-GB")
+                    : "N/A"}
+                </TableCell>                <TableCell>
                   <div className="flex gap-2">
                     <Tooltip>
                       <TooltipTrigger asChild>

--- a/src/components/claims/tp/TpSubmitDialog.tsx
+++ b/src/components/claims/tp/TpSubmitDialog.tsx
@@ -28,7 +28,7 @@ const TpSubmitDialog: React.FC<TpSubmitDialogProps> = ({ isOpen, onClose, claim 
       // Invalidate the query to refresh the ClaimList
       queryClient.invalidateQueries({ queryKey: ["claimStats"] });
       queryClient.invalidateQueries({ queryKey: ["fetchClaimTP"] });
-      queryClient.invalidateQueries({ queryKey: ["fetchClaimById", claim.id] });
+      queryClient.invalidateQueries({ queryKey: ["fetchClaimById"] });
 
       onClose();
     } catch (error) {

--- a/src/components/claims/tp/hooks/fetch-claim-tp.ts
+++ b/src/components/claims/tp/hooks/fetch-claim-tp.ts
@@ -10,7 +10,7 @@ export const useFetchClaimTP = () => {
   const organizationId = parsedMetadata?.organization_id;
 
   return useQuery({
-    queryKey: ["fetchClaimTP", organizationId],
+    queryKey: ["fetchClaimTP"],
     queryFn: async () => {
       if (!organizationId) return [];
 


### PR DESCRIPTION
This pull request includes updates to the claims components and hooks to improve date handling and simplify query invalidation logic. The changes focus on ensuring consistent timezone adjustments, handling missing data gracefully, and streamlining query keys for better maintainability.

### Updates to date handling:

* [`src/components/claims/dusp/ClaimListDusp.tsx`](diffhunk://#diff-b898def2c2b60c60719b17e1c727054837c7ad686ed240036c7d1a13f9cb2716L241-R245): Adjusted the `updated_at` timestamp to account for timezone differences (+8 hours) and switched to `en-GB` locale formatting. Added a fallback for cases where `updated_at` is missing, displaying "N/A" instead.
* [`src/components/claims/tp/ClaimListTp.tsx`](diffhunk://#diff-2d0a948e0fbbd6679f9702eca494a7cfef730393f5bd182e506a404b17999c22L230-R234): Applied the same timezone adjustment and fallback logic for the `updated_at` timestamp as in `ClaimListDusp`.

### Simplification of query invalidation:

* `src/components/claims/dusp/DuspSubmitDialog.tsx` and `src/components/claims/dusp/DuspUpdatePaymentDialog.tsx`: Removed the `claim.id` parameter from `fetchClaimById` query invalidation to simplify query keys. [[1]](diffhunk://#diff-e4ab10d23b035b1a103bc8c580de3248fe6494e46d18230282d6432ef02e633dL31-R31) [[2]](diffhunk://#diff-c32577e49c8c02ef646072b9b74e6e6324542e4fbeaaa2581f0536c0a2aa67eeL36-R36)
* [`src/components/claims/tp/TpSubmitDialog.tsx`](diffhunk://#diff-988a24226b94ae7c4e939d44c458ab021f32a833dde211f84294d620ea0faf37L31-R31): Streamlined query invalidation by removing the `claim.id` parameter from `fetchClaimById` query keys.

### Updates to query hooks:

* [`src/components/claims/dusp/hooks/fetch-claim-dusp.ts`](diffhunk://#diff-aa85d177afc2f2f6a40a39813472ec7bba64da87e7863b1c3f1e3d73f7ef5cc4L11-R11): Simplified the `queryKey` for `fetchClaimDUSP` by removing the `organizationId` parameter.
* [`src/components/claims/tp/hooks/fetch-claim-tp.ts`](diffhunk://#diff-583c4f7a452ed03683fea3602527cbab12029f2b70015c8a922515a351356d32L13-R13): Updated the `queryKey` for `fetchClaimTP` to exclude the `organizationId` parameter for consistency with other queries.