### PR TITLE
Claim bug

### DIFF
--- a/src/components/claims/form/ClaimApplicationForm.tsx
+++ b/src/components/claims/form/ClaimApplicationForm.tsx
@@ -136,7 +136,7 @@ export function ClaimApplicationForm({
   return (
     <div>
       <header className="mb-4">Phase, Items, & Sites</header>
-      <pre>{JSON.stringify(category_ids, null, 2)}</pre>
+      {/* <pre>{JSON.stringify(category_ids, null, 2)}</pre> */}
 
       {/* Phase Selection */}
       <div className="space-y-2 mb-4">

--- a/src/components/claims/form/ClaimApplicationForm.tsx
+++ b/src/components/claims/form/ClaimApplicationForm.tsx
@@ -136,7 +136,7 @@ export function ClaimApplicationForm({
   return (
     <div>
       <header className="mb-4">Phase, Items, & Sites</header>
-      {/* <pre>{JSON.stringify(category_ids, null, 2)}</pre> */}
+      <pre>{JSON.stringify(category_ids, null, 2)}</pre>
 
       {/* Phase Selection */}
       <div className="space-y-2 mb-4">
@@ -233,22 +233,24 @@ export function ClaimApplicationForm({
                                 ? (() => {
                                   const existingCategory = category_ids.find((cat) => cat.id === category.id);
                                   if (existingCategory) {
-                                    // Add all items in the category to item_ids
+                                    // Add only items that are not already present
+                                    const newItems = category.children.filter(
+                                      (item) =>
+                                        !existingCategory.item_ids.some((existingItem) => existingItem.id === item.id)
+                                    ).map((item) => ({
+                                      id: item.id,
+                                      name: item.name,
+                                      need_support_doc: item.need_support_doc,
+                                      need_summary_report: item.need_summary_report,
+                                      summary_report_file: null, // Reset file on selection
+                                      site_ids: sites.map((site) => site.id), // Auto-select all sites
+                                    }));
+
                                     return category_ids.map((cat) =>
                                       cat.id === category.id
                                         ? {
                                           ...cat,
-                                          item_ids: [
-                                            ...cat.item_ids,
-                                            ...category.children.map((item) => ({
-                                              id: item.id,
-                                              name: item.name,
-                                              need_support_doc: item.need_support_doc,
-                                              need_summary_report: item.need_summary_report,
-                                              summary_report_file: null, // Reset file on selection
-                                              site_ids: sites.map((site) => site.id), // Auto-select all sites
-                                            })),
-                                          ],
+                                          item_ids: [...cat.item_ids, ...newItems],
                                         }
                                         : cat
                                     );


### PR DESCRIPTION
This pull request refines the logic for adding items to a category in the `ClaimApplicationForm` component. The change ensures that only new items (those not already present in the category) are added, improving the efficiency and correctness of the item selection process.

Key change in item selection logic:

* [`src/components/claims/form/ClaimApplicationForm.tsx`](diffhunk://#diff-981e943e0de1b57506db8a93445566ba85e46c72363903b3514e5bef9b45f730L236-R253): Updated the logic to filter out items that are already present in the category before adding new items. This prevents duplicate entries and ensures proper handling of item selection.