### PR TITLE
Claim v1

### DIFF
--- a/src/components/claims/component/ClaimStatusLegend.tsx
+++ b/src/components/claims/component/ClaimStatusLegend.tsx
@@ -28,7 +28,7 @@ const ClaimStatusDescriptionDialog: React.FC<ClaimStatusDescriptionDialogProps> 
     >([]);
     const [loading, setLoading] = useState<boolean>(true);
 
-    const statuses = ["DRAFTED", "SUBMITTED", "PROCESSING", "COMPLETED"];
+    const statuses = ["DRAFTED", "SUBMITTED", "PROCESSING", "COMPLETED", "REJECTED"];
 
     useEffect(() => {
         const fetchDescriptions = async () => {
@@ -61,6 +61,8 @@ const ClaimStatusDescriptionDialog: React.FC<ClaimStatusDescriptionDialogProps> 
                 return "warning";
             case "COMPLETED":
                 return "success";
+            case "REJECTED":
+                return "destructive";
             default:
                 return "secondary";
         }
@@ -68,7 +70,7 @@ const ClaimStatusDescriptionDialog: React.FC<ClaimStatusDescriptionDialogProps> 
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent className="sm:max-w-[600px]">
+            <DialogContent className="sm:max-w-[670px]">
                 <DialogHeader>
                     <DialogTitle>Claim Status Flow</DialogTitle>
                     <DialogDescription></DialogDescription>

--- a/src/components/claims/component/ClaimViewDialog.tsx
+++ b/src/components/claims/component/ClaimViewDialog.tsx
@@ -12,6 +12,7 @@ import DuspUpdatePaymentDialog from "../dusp/DuspUpdatePaymentDialog";
 import { useNavigate } from "react-router-dom";
 import { ApplicationTab } from "./tab/ApplicationTab";
 import { useToast } from "@/hooks/use-toast";
+import DuspRejectDialog from "../dusp/DuspRejectDialog";
 
 interface ClaimViewPageProps {
   claimId: number; // Accept claimId as a prop
@@ -26,6 +27,7 @@ const ClaimViewPage: React.FC<ClaimViewPageProps> = ({ claimId }) => {
   const userType = parsedMetadata?.user_type;
   const [activeTab, setActiveTab] = useState("general");
   const [isSubmitDialogOpen, setIsSubmitDialogOpen] = useState(false); // State for TpSubmitDialog
+  const [isRejectDialogOpen, setIsRejectDialogOpen] = useState(false); // State for TpSubmitDialog
   const [isDuspDialogOpen, setIsDuspDialogOpen] = useState(false); // State for DuspSubmitDialog
   const [isUpdatePaymentDialogOpen, setIsUpdatePaymentDialogOpen] = useState(false); // State for DuspUpdatePaymentDialog
 
@@ -90,33 +92,45 @@ const ClaimViewPage: React.FC<ClaimViewPageProps> = ({ claimId }) => {
           )}
 
           {userGroup === 1 && claimData?.claim_status?.name === "SUBMITTED" && (
-            <Button
-              variant="default"
-              onClick={() => {
-                if (!claimData.signed_documents || claimData.signed_documents.length === 0) {
-                  toast({
-                    title: "Signed Document Required",
-                    description: "Please upload the signed the document before submitting to MCMC.",
-                    variant: "destructive",
-                  });
-                  setActiveTab("sign");
-                  return;
-                }
-                if (claimData.noa === null || claimData.noa === "") {
-                  toast({
-                    title: "NOA Required",
-                    description: "Please insert NOA before submitting to MCMC.",
-                    variant: "destructive",
-                  });
-                  setActiveTab("sign");
-                  return;
-                }
-                setIsDuspDialogOpen(true); // Open DuspSubmitDialog
-              }}
-              disabled={!claimData} // Disable if claimData is not loaded
-            >
-              Save
-            </Button>
+            <div>
+              <Button
+              className="mr-2"
+                variant="destructive"
+                onClick={() => {
+                  setIsRejectDialogOpen(true); // Open DuspSubmitDialog
+                }}
+                disabled={!claimData} // Disable if claimData is not loaded
+              >
+                Reject
+              </Button>
+              <Button
+                variant="default"
+                onClick={() => {
+                  if (!claimData.signed_documents || claimData.signed_documents.length === 0) {
+                    toast({
+                      title: "Signed Document Required",
+                      description: "Please upload the signed the document before submitting to MCMC.",
+                      variant: "destructive",
+                    });
+                    setActiveTab("sign");
+                    return;
+                  }
+                  if (claimData.noa === null || claimData.noa === "") {
+                    toast({
+                      title: "NOA Required",
+                      description: "Please insert NOA before submitting to MCMC.",
+                      variant: "destructive",
+                    });
+                    setActiveTab("sign");
+                    return;
+                  }
+                  setIsDuspDialogOpen(true); // Open DuspSubmitDialog
+                }}
+                disabled={!claimData} // Disable if claimData is not loaded
+              >
+                Save / Submit
+              </Button>
+            </div>
           )}
 
           {userGroup === 1 && claimData?.claim_status?.name === "PROCESSING" && (
@@ -145,6 +159,15 @@ const ClaimViewPage: React.FC<ClaimViewPageProps> = ({ claimId }) => {
         <DuspSubmitDialog
           isOpen={isDuspDialogOpen}
           onClose={() => setIsDuspDialogOpen(false)} // Close DuspSubmitDialog
+          claim={claimData} // Pass claimData to DuspSubmitDialog
+        />
+      )}
+
+      {/* DuspRejectDialog */}
+      {claimData && (
+        <DuspRejectDialog
+          isOpen={isRejectDialogOpen}
+          onClose={() => setIsRejectDialogOpen(false)} // Close DuspSubmitDialog
           claim={claimData} // Pass claimData to DuspSubmitDialog
         />
       )}

--- a/src/components/claims/component/tab/GeneralTab.tsx
+++ b/src/components/claims/component/tab/GeneralTab.tsx
@@ -51,6 +51,8 @@ const GeneralTab: React.FC<GeneralTabProps> = ({ claimData }) => {
                 return "warning";
             case "COMPLETED":
                 return "success";
+            case "REJECTED":
+                return "destructive";
             default:
                 return "secondary";
         }

--- a/src/components/claims/dusp/DuspRejectDialog.tsx
+++ b/src/components/claims/dusp/DuspRejectDialog.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from "@/components/ui/dialog";
+import { updateClaim } from "../hook/update-claim"; // Import the update function
+import { useToast } from "@/components/ui/use-toast";
+import { useQueryClient } from "@tanstack/react-query";
+
+interface DuspRejectDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  claim: any;
+}
+
+const DuspRejectDialog: React.FC<DuspRejectDialogProps> = ({ isOpen, onClose, claim }) => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [remark, setRemark] = useState("");
+
+  const handleSubmit = async () => {
+    try {
+      await updateClaim({
+        claim_id: claim.id,
+        claim_status: 5,
+        request_remark: remark,
+      });
+      toast({ title: "Success", description: "Claim rejected successfully." });
+
+      // Invalidate the query to refresh the ClaimList
+      queryClient.invalidateQueries({ queryKey: ["claimStats"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchClaimDUSP"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchClaimById"] });
+
+
+      onClose();
+    } catch (error) {
+      toast({ title: "Error", description: "Failed to reject claim.", variant: "destructive" });
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reject Claim</DialogTitle>
+          <DialogDescription className="text-muted-foreground mb-4">
+            Provide a remark for your rejection.
+          </DialogDescription>
+        </DialogHeader>
+        <textarea
+          className="w-full border rounded-md p-2"
+          placeholder="Enter your remark..."
+          value={remark}
+          onChange={(e) => setRemark(e.target.value)}
+        />
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit}>Submit</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DuspRejectDialog;

--- a/src/components/claims/tp/ClaimForm.tsx
+++ b/src/components/claims/tp/ClaimForm.tsx
@@ -73,7 +73,7 @@ const INITIAL_DATA: FormData = {
 const ClaimFormPage = () => {
   const queryClient = useQueryClient();
   const [isDialogOpen, setIsDialogOpen] = useState(false); // State for dialog visibility
-
+  const [isCheckboxChecked, setIsCheckboxChecked] = useState(false); // State for checkbox
   const { duspTpData, isLoading, error } = useDuspTpData();
   const [data, setData] = useState({
     ...INITIAL_DATA,
@@ -274,7 +274,12 @@ const ClaimFormPage = () => {
       </Card>
 
       {/* Confirmation Dialog */}
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <Dialog open={isDialogOpen} onOpenChange={(isOpen) => {
+        setIsDialogOpen(isOpen);
+        if (!isOpen) {
+          setIsCheckboxChecked(false); // Reset checkbox state when dialog is closed
+        }
+      }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Confirm Draft Claim</DialogTitle>
@@ -282,11 +287,29 @@ const ClaimFormPage = () => {
           </DialogHeader>
           <p>Are you sure you want to create this draft claim?</p>
           <p>Once created, the report cannot be regenerated</p>
+          <div className="flex items-center mt-4">
+            <input
+              type="checkbox"
+              id="confirm-checkbox"
+              className="mr-2"
+              onChange={(e) => setIsCheckboxChecked(e.target.checked)}
+            />
+            <label htmlFor="confirm-checkbox" className="text-sm text-gray-600">
+              I understand and confirm this action
+            </label>
+          </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
+            <Button variant="outline" onClick={() => {
+              setIsCheckboxChecked(false); // Reset the checkbox state
+              setIsDialogOpen(false)
+            }}>
               Cancel
             </Button>
-            <Button variant="default" onClick={handleConfirm} disabled={loading}>
+            <Button
+              variant="default"
+              onClick={handleConfirm}
+              disabled={loading || !isCheckboxChecked} // Disable if loading or checkbox is not checked
+            >
               {loading ? (
                 <div className="flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin" /> {/* Spinner */}

--- a/src/components/claims/tp/ClaimListTp.tsx
+++ b/src/components/claims/tp/ClaimListTp.tsx
@@ -138,6 +138,8 @@ export function ClaimListTp() {
         return "warning";
       case "COMPLETED":
         return "success";
+      case "REJECTED":
+        return "destructive";
       default:
         return "secondary";
     }


### PR DESCRIPTION
This pull request introduces enhancements to the claims management system, including support for a new "REJECTED" claim status, a reject claim dialog for DUSP users, and a confirmation dialog for draft claims in the TP workflow. These changes improve functionality and user experience by adding new features and refining existing ones.

### Enhancements to Claim Status Handling:
* Added "REJECTED" as a new claim status in the `statuses` array in `ClaimStatusLegend.tsx` and updated the `getStatusColor` function to return "destructive" for this status. [[1]](diffhunk://#diff-08cf8d5364358ea94111696ac98aa2f60e9524eace928d8aa420efa43a9e185fL31-R31) [[2]](diffhunk://#diff-08cf8d5364358ea94111696ac98aa2f60e9524eace928d8aa420efa43a9e185fR64-R73) [[3]](diffhunk://#diff-6d7afb0f50689f364b7d259dcadcc84c661ed9f5cf250ec38fa8943cd80f89daR54-R55) [[4]](diffhunk://#diff-2d0a948e0fbbd6679f9702eca494a7cfef730393f5bd182e506a404b17999c22R141-R142)

### DUSP Reject Claim Dialog:
* Implemented `DuspRejectDialog` component to allow DUSP users to reject claims with a remark. Includes integration with the `updateClaim` function and query invalidation for claim-related data.
* Integrated `DuspRejectDialog` in `ClaimViewDialog.tsx` with a new "Reject" button for claims in "SUBMITTED" status, along with state management for dialog visibility. [[1]](diffhunk://#diff-41448a612bbb37c171fe986e80c7cdea737c0d14baef57eb710c4372b6863d31R15) [[2]](diffhunk://#diff-41448a612bbb37c171fe986e80c7cdea737c0d14baef57eb710c4372b6863d31R30) [[3]](diffhunk://#diff-41448a612bbb37c171fe986e80c7cdea737c0d14baef57eb710c4372b6863d31R95-R105) [[4]](diffhunk://#diff-41448a612bbb37c171fe986e80c7cdea737c0d14baef57eb710c4372b6863d31R166-R174)

### TP Draft Claim Confirmation Dialog:
* Added a confirmation dialog in `ClaimForm.tsx` for TP users when creating draft claims. Includes checkbox validation to ensure users acknowledge the action before proceeding. [[1]](diffhunk://#diff-21a5bb0364d7b82156841f33c230ee751a71ac1316cbf3ace34098a81c206acbR14) [[2]](diffhunk://#diff-21a5bb0364d7b82156841f33c230ee751a71ac1316cbf3ace34098a81c206acbL74-R76) [[3]](diffhunk://#diff-21a5bb0364d7b82156841f33c230ee751a71ac1316cbf3ace34098a81c206acbR186-R190) [[4]](diffhunk://#diff-21a5bb0364d7b82156841f33c230ee751a71ac1316cbf3ace34098a81c206acbL214-R221) [[5]](diffhunk://#diff-21a5bb0364d7b82156841f33c230ee751a71ac1316cbf3ace34098a81c206acbR275-R324)